### PR TITLE
Add BioCLIP 2.5 Huge

### DIFF
--- a/pages/models.html
+++ b/pages/models.html
@@ -35,13 +35,13 @@
             <div class="decision-guide decision-guide--grid-2">
                 <div class="guide-card">
                     <span class="guide-icon">🚀</span>
-                    <h3 class="guide-title">State-of-the-Art</h3>
+                    <h3 class="guide-title">State-of-the-Art (Huge)</h3>
                     <p class="guide-desc">I need the latest model with the highest accuracy (ViT-H) and emergent biological capabilities. Speed and size are not an issue.</p>
                     <a href="#bioclip-2.5-huge" class="guide-link">Go to BioCLIP 2.5 Huge &rarr;</a>
                 </div>
                 <div class="guide-card">
                     <span class="guide-icon">🚀</span>
-                    <h3 class="guide-title">State-of-the-Art</h3>
+                    <h3 class="guide-title">State-of-the-Art (Large)</h3>
                     <p class="guide-desc">I have inference speed or size constraints, but need the latest model with the highest accuracy (ViT-L) and emergent biological capabilities.</p>
                     <a href="#bioclip-2" class="guide-link">Go to BioCLIP 2 &rarr;</a>
                 </div>


### PR DESCRIPTION
Closes #20. 
We should probably update the image for BioCLIP 2.5 Huge, though. #15 covers icon updates for the "Choose Your Model" section.

<img width="1500" height="609" alt="Screenshot 2026-02-24 at 1 18 46 PM" src="https://github.com/user-attachments/assets/57eb26a3-625c-40c7-86a8-cae7926bd365" />
<img width="1509" height="643" alt="Screenshot 2026-02-24 at 1 16 54 PM" src="https://github.com/user-attachments/assets/db13f2ce-8bcc-4ba9-9306-f4ffbf23b461" />

I also added clarification on the revision of TOL-200M used for BioCLIP 2.