### PR TITLE
Move hugging face collection section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,33 @@
         </div>
     </section>
 
+    <section id="collection" class="section bg-light">
+        <div class="container">
+            <div class="component-row">
+                <div class="component-text">
+                    <span class="tag tool">Repository</span>
+                    <h2>Hugging Face Collection</h2>
+                    <p>
+                        The central warehouse for all BioCLIP assets. This collection aggregates all versions of the models, the training datasets, benchmarks, and interactive demos.
+                    </p>
+                    <p>
+                        Use this if you need direct access to raw model weights (SafeTensors/PyTorch), want to access the TreeOfLife or benchmark datasets, or are looking for easy by-image predictions.
+                    </p>
+                    <ul class="feature-list">
+                        <li><strong>Models:</strong> BioCLIP, BioCLIP 2, BioCAP, BioCLIP 2.5 Huge.</li>
+                        <li><strong>Datasets:</strong> TreeOfLife-200M, TreeOfLife-10M, TreeOfLife-10M Captions.</li>
+                        <li><strong>Benchmarks:</strong> Rare Species, IDLE-OO Camera Traps.</li>
+                        <li><strong>Demos:</strong> Interactive Gradio apps for zero-shot and open-ended classification.</li>
+                    </ul>
+                    <a href="https://huggingface.co/collections/imageomics/bioclip" class="btn btn-primary">Browse Collection</a>
+                </div>
+                <div class="component-image img-hf">
+                    🤗 Data, Models, and Demos
+                </div>
+            </div>
+        </div>
+    </section>
+
     <script>
         lucide.createIcons();
     </script>

--- a/pages/data.html
+++ b/pages/data.html
@@ -244,29 +244,5 @@
         </section>
     </section>
 
-    <section id="collection" class="section bg-light">
-        <div class="container">
-            <div class="component-row">
-                <div class="component-text">
-                    <span class="tag tool">Repository</span>
-                    <h2>Hugging Face Collection</h2>
-                    <p>
-                        The central warehouse for all BioCLIP assets. This collection aggregates all versions of the models, the training datasets, benchmarks, and interactive demos.
-                    </p>
-                    <p>
-                        Use this if you need direct access to the TreeOfLife datasets or evaluation benchmarks.
-                    </p>
-                    <ul class="feature-list">
-                        <li><strong>Datasets:</strong> TreeOfLife-200M, TreeOfLife-10M, TreeOfLife-10M Captions.</li>
-                        <li><strong>Benchmarks:</strong> Rare Species, IDLE-OO Camera Traps.</li>
-                    </ul>
-                    <a href="https://huggingface.co/collections/imageomics/bioclip" class="btn btn-primary">Browse Collection</a>
-                </div>
-                <div class="component-image img-hf">
-                    🤗 Hugging Face Collection
-                </div>
-            </div>
-        </div>
-    </section>
 </body>
 </html>

--- a/pages/models.html
+++ b/pages/models.html
@@ -185,31 +185,5 @@
         </div>
     </section>
 
-    <section id="collection" class="section bg-light">
-        <div class="container">
-            <div class="component-row">
-                <div class="component-text">
-                    <span class="tag tool">Repository</span>
-                    <h2>Hugging Face Collection</h2>
-                    <p>
-                        The central warehouse for all BioCLIP assets. This collection aggregates all versions of the models, the training datasets, benchmarks, and interactive demos.
-                    </p>
-                    <p>
-                        Use this if you need direct access to raw model weights (SafeTensors/PyTorch), want to access the TreeOfLife or benchmark datasets, or are looking for easy by-image predictions.
-                    </p>
-                    <ul class="feature-list">
-                        <li><strong>Models:</strong> BioCLIP, BioCLIP 2, BioCAP.</li>
-                        <li><strong>Datasets:</strong> TreeOfLife-200M, TreeOfLife-10M, TreeOfLife-10M Captions.</li>
-                        <li><strong>Benchmarks:</strong> Rare Species, IDLE-OO Camera Traps.</li>
-                        <li><strong>Demos:</strong> Interactive Gradio apps for zero-shot and open-ended classification.</li>
-                    </ul>
-                    <a href="https://huggingface.co/collections/imageomics/bioclip" class="btn btn-primary">Browse Collection</a>
-                </div>
-                <div class="component-image img-hf">
-                    🤗 Hugging Face Collection
-                </div>
-            </div>
-        </div>
-    </section>
 </body>
 </html>


### PR DESCRIPTION
Closes #19.

Removes Hugging Face collection sections from Models and Data pages, instead maintaining it on just the homepage:

<img width="1359" height="635" alt="Screenshot 2026-02-27 at 6 27 07 PM" src="https://github.com/user-attachments/assets/1afec6ca-36a3-4055-9b74-06011b0c800a" />