### PR TITLE
Add pybioclip video link to software page

### DIFF
--- a/pages/software.html
+++ b/pages/software.html
@@ -104,6 +104,7 @@ TODO: Add BioCLIP associated software:
                         </ul>
                     </p>
                     <a href="https://imageomics.github.io/pybioclip/" class="btn btn-primary">Read Documentation</a>
+                    <a href="https://www.youtube.com/watch?v=kVsGDiN7fTg" class="btn btn-outline ml-2">Watch Intro Video</a>
                     <a href="https://github.com/Imageomics/pybioclip" class="btn btn-outline ml-2">View on GitHub</a>
                 </div>
                 <div class="component-image img-pybioclip">


### PR DESCRIPTION
Adds a new button, "Watch Intro Video", that links to the [pybioclip intro video](https://www.youtube.com/watch?v=kVsGDiN7fTg) on the Imageomics Youtube.

<img width="1360" height="699" alt="Screenshot 2026-04-01 at 11 10 02 AM" src="https://github.com/user-attachments/assets/84b996b1-d77d-4d04-931e-f1e1fc920d50" />

Closes #36 