### PR TITLE
Update model icons and card format

### DIFF
--- a/pages/models.html
+++ b/pages/models.html
@@ -34,32 +34,32 @@
             
             <div class="decision-guide decision-guide--grid-2">
                 <div class="guide-card">
-                    <span class="guide-icon">🚀</span>
+                    <span class="guide-icon"><i data-lucide="spotlight"></i></span>
                     <h3 class="guide-title">State-of-the-Art (Huge)</h3>
                     <p class="guide-desc">I need the latest model with the highest accuracy (ViT-H) and emergent biological capabilities. Speed and size are not an issue.</p>
                     <a href="#bioclip-2.5-huge" class="guide-link">Go to BioCLIP 2.5 Huge &rarr;</a>
                 </div>
                 <div class="guide-card">
-                    <span class="guide-icon">🚀</span>
+                    <span class="guide-icon"><i data-lucide="rocket"></i></span>
                     <h3 class="guide-title">State-of-the-Art (Large)</h3>
                     <p class="guide-desc">I have inference speed or size constraints, but need the latest model with the highest accuracy (ViT-L) and emergent biological capabilities.</p>
                     <a href="#bioclip-2" class="guide-link">Go to BioCLIP 2 &rarr;</a>
                 </div>
                 <div class="guide-card">
-                    <span class="guide-icon">📃</span>
+                    <span class="guide-icon"><i data-lucide="captions"></i></span>
                     <h3 class="guide-title">Trained with Captions</h3>
                     <p class="guide-desc">I need a ViT-B/16 model for inference speed or direct comparison; looking for base model trained with captions and taxonomic labels.</p>
                     <!--want to try BioCAP, the original BioCLIP model, but trained with captions and taxonomic labels-->
                     <a href="#biocap" class="guide-link">Go to BioCAP &rarr;</a>
                 </div>
                 <div class="guide-card">
-                    <span class="guide-icon">📜</span>
+                    <span class="guide-icon"><i data-lucide="save"></i></span>
                     <h3 class="guide-title">Original</h3>
                     <p class="guide-desc">I need the original BioCLIP ViT-B model described in the 2024 CVPR paper.</p>
                     <a href="#bioclip" class="guide-link">Go to BioCLIP &rarr;</a>
                 </div>
                 <div class="guide-card">
-                    <span class="guide-icon">💾</span>
+                    <span class="guide-icon"><i data-lucide="library-big"></i></span>
                     <h3 class="guide-title">Raw Models</h3>
                     <p class="guide-desc">I want to download weights or try demos.</p>
                     <a href="#collection" class="guide-link">Go to HF Collection &rarr;</a>

--- a/pages/models.html
+++ b/pages/models.html
@@ -32,7 +32,7 @@
             <h2 class="section-title">Which BioCLIP model do you need?</h2>
             <!-- BioCAP is it still just classification -->
             
-            <div class="decision-guide decision-guide--grid-2">
+            <div class="decision-guide decision-guide--grid-3">
                 <div class="guide-card">
                     <span class="guide-icon"><i data-lucide="spotlight"></i></span>
                     <h3 class="guide-title">State-of-the-Art (Huge)</h3>

--- a/pages/models.html
+++ b/pages/models.html
@@ -36,13 +36,13 @@
                 <div class="guide-card">
                     <span class="guide-icon"><i data-lucide="spotlight"></i></span>
                     <h3 class="guide-title">State-of-the-Art (Huge)</h3>
-                    <p class="guide-desc">I need the latest model with the highest accuracy (ViT-H) and emergent biological capabilities. Speed and size are not an issue.</p>
+                    <p class="guide-desc">I need the latest model with the highest accuracy (ViT-H/14) and emergent biological capabilities. Speed and size are not an issue.</p>
                     <a href="#bioclip-2.5-huge" class="guide-link">Go to BioCLIP 2.5 Huge &rarr;</a>
                 </div>
                 <div class="guide-card">
                     <span class="guide-icon"><i data-lucide="rocket"></i></span>
                     <h3 class="guide-title">State-of-the-Art (Large)</h3>
-                    <p class="guide-desc">I have inference speed or size constraints, but need the latest model with the highest accuracy (ViT-L) and emergent biological capabilities.</p>
+                    <p class="guide-desc">I have inference speed or size constraints, but need the latest model with the highest accuracy (ViT-L/14) and emergent biological capabilities.</p>
                     <a href="#bioclip-2" class="guide-link">Go to BioCLIP 2 &rarr;</a>
                 </div>
                 <div class="guide-card">
@@ -55,7 +55,7 @@
                 <div class="guide-card">
                     <span class="guide-icon"><i data-lucide="save"></i></span>
                     <h3 class="guide-title">Original</h3>
-                    <p class="guide-desc">I need the original BioCLIP ViT-B model described in the 2024 CVPR paper.</p>
+                    <p class="guide-desc">I need the original BioCLIP ViT-B/16 model described in the 2024 CVPR paper.</p>
                     <a href="#bioclip" class="guide-link">Go to BioCLIP &rarr;</a>
                 </div>
                 <div class="guide-card">


### PR DESCRIPTION
Also added the patch size indicator for models from which it had been excluded.

Set the choose your model grid to 3, matching the data page. With new models coming soon, this makes it more approachable.

<img width="1317" height="636" alt="Screenshot 2026-05-28 at 7 37 17 PM" src="https://github.com/user-attachments/assets/3aaefee1-7ac4-456b-b849-bfd2a02f8969" />

Closes #15.