### PR TITLE
Initialize community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The site runs based on the following files. All site images are called from the 
   * `papers.html`: Includes abstracts and links to papers and project-specific sites for each BioCLIP publication.
   * `software.html`: Describes and links to all software used in creating the models and datasets, as well as those to explore and more easily utilize them (e.g., `TaxonoPy` and `pybioclip`).
   * `roadmap.html`: Describes plans for future ecosystem projects and updates, including models, data, software products, and community initiatives.
+  * `community.html`: Describes and links to various community development initiatives (currently in development).
 
 ## Local Testing
 

--- a/js/load-components.js
+++ b/js/load-components.js
@@ -35,7 +35,8 @@
         { id: 'nav-software', relPath: 'pages/software.html', fileName: 'software.html', label: 'Software' },
         { id: 'nav-demos',    relPath: 'pages/demos.html',    fileName: 'demos.html',    label: 'Demos'    },
         { id: 'nav-papers',   relPath: 'pages/papers.html',   fileName: 'papers.html',   label: 'Papers'   },
-        { id: 'nav-roadmap',  relPath: 'pages/roadmap.html',  fileName: 'roadmap.html',  label: 'Roadmap'  }
+        { id: 'nav-roadmap',  relPath: 'pages/roadmap.html',  fileName: 'roadmap.html',  label: 'Roadmap'  },
+        { id: 'nav-community', relPath: 'pages/community.html', fileName: 'community.html', label: 'Community' }
     ];
 
     // Build and inject nav links into both desktop and mobile navs

--- a/pages/community.html
+++ b/pages/community.html
@@ -1,9 +1,13 @@
 <!--
-TODO: Add content
+TODO: Add content as it's available:
 - Get Involved
 - Community Highlights
-- Leaderboard? (e.g., biobench?)
-- Community initiatives (e.g. workshops, challenges, etc.)?
+- BioCLIP Helpdesk
+- WildLabs Group
+- Community Forum
+- Community Highlights: will need PR or issue template to submit to this site repo
+- Community Contributions: auto load "help wanted" OR "good first issue" GitHub issues across ecosystem repos?
+- Leaderboard (biobench?): Need submission protocol with rendered leaderboard in right image space (include Model name, link to model, performance metric)
 -->
 
 <!DOCTYPE html>

--- a/pages/community.html
+++ b/pages/community.html
@@ -1,0 +1,44 @@
+<!--
+TODO: Add content
+- Get Involved
+- Community Highlights
+- Leaderboard? (e.g., biobench?)
+- Community initiatives (e.g. workshops, challenges, etc.)?
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BioCLIP Ecosystem | Community</title>
+    <meta name="description" content="Join and engage with the BioCLIP ecosystem community.">
+
+    <link rel="stylesheet" href="../css/variables.css">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="icon" type="image/png"
+        href="https://github.com/Imageomics/Imageomics-guide/raw/3478acc0068a87a5604069d04a29bdb0795c2045/docs/logos/Imageomics_logo_butterfly.png">
+    <script src="../js/load-components.js" defer></script>
+</head>
+
+<body>
+
+    <section class="hero">
+        <div class="container">
+            <h1>Ecosystem Community</h1>
+            <p>
+                Join and engage with the BioCLIP ecosystem community. Find ways to contribute, share your work, and connect with others interested in vision models for the Tree of Life.
+            </p>
+            <div class="hero-actions">
+                <a href="#guide" class="btn btn-primary">Get Involved (Coming soon!)</a>
+                <!--<a href="#browse" class="btn btn-outline">Browse Involvement Opportunities</a>-->
+            </div>
+        </div>
+    </section>
+
+
+    
+</body>
+
+</html>


### PR DESCRIPTION
This is mostly a 'coming soon' placeholder. With this update, the [Roadmap Community button link](https://imageomics.github.io/bioclip-ecosystem/pages/roadmap.html#future-community) will direct to this page--should we keep the "coming soon" there too?

<img width="1106" height="464" alt="Screenshot 2026-06-02 at 11 21 45 AM" src="https://github.com/user-attachments/assets/b79e0e85-85b1-4a20-9304-65eb51dfa7a3" />

I have a scaffold for this that I could comment out at the bottom, but I outlined it at the top under "TODO", which is probably cleaner for now.