### PR TITLE
Add community page issues and biobench

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1138,13 +1138,14 @@ p {
   max-height: 480px;
   overflow-y: auto;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  padding: 4px;
+  padding: 8px;
 }
 
 .issue-card-content {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  padding: 8px;
 }
 
 /* Subtle row hover interactive animations */
@@ -1154,6 +1155,14 @@ p {
   border-bottom: 1px;
   border-color: solid #f1f1f1; 
   padding: 2px 1px;
+}
+
+.issue-item:hover {
+  background-color: #f6f8fa;
+}
+
+.issue-item:hover .issue-title {
+  color: var(--color-accent);
 }
 
 /* Text status indicators */

--- a/css/style.css
+++ b/css/style.css
@@ -1148,6 +1148,21 @@ p {
   padding: 8px;
 }
 
+.issue-repo-name {
+  font-weight: 600;
+  color: var(--color-primary-dark)
+}
+
+.issue-number {
+    color: var(--color-primary-dark);
+}
+
+.issue-title {
+    font-size: 0.95rem;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
 /* Subtle row hover interactive animations */
 .issue-item {
   transition: background-color 0.15s ease;
@@ -1161,7 +1176,7 @@ p {
   background-color: #f6f8fa;
 }
 
-.issue-item:hover .issue-title {
+.issue-item:hover .issue-title, .issue-item:hover .issue-repo-name, .issue-item:hover .issue-number {
   color: var(--color-accent);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1127,3 +1127,42 @@ p {
         height: 140px;
     }
 }
+
+/** Issue List Box Style */
+
+/* Container wrap layout */
+.issue-box-container {
+  border: 1px solid #e1e4e8;
+  border-radius: 4px;
+  background-color: #ffffff;
+  max-height: 480px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  padding: 4px;
+}
+
+.issue-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Subtle row hover interactive animations */
+.issue-item {
+  transition: background-color 0.15s ease;
+  border-radius: 4px;
+  border-bottom: 1px;
+  border-color: solid #f1f1f1; 
+  padding: 2px 1px;
+}
+
+/* Text status indicators */
+.issue-loading, .issue-empty, .issue-error {
+  text-align: center;
+  color: #586069;
+  font-style: italic;
+  padding: 32px 0;
+}
+.issue-error {
+  color: #cb2431;
+}

--- a/js/load-issues.js
+++ b/js/load-issues.js
@@ -80,62 +80,63 @@ export async function loadGitHubIssues(containerId) {
                     const urlParts = issue.html_url.split('/');
                     const repoName = urlParts[4] || 'Repository';
 
-                    // Map issue labels and build their badges with inline safety styles
+                    // Map issue labels and build their badges with inline styles
+                    // Badges use the GitHub label color, with gray as fallback, and dynamic text color for contrast
                     const tagsHtml = (issue.labels || []).map(label => {
-                    // Fallback to light gray if color is missing
-                    const bgColor = label.color ? `#${label.color}` : '#f1f3f5';
-                    
-                    // Dynamically calculate text contrast (Light vs Dark backgrounds)
-                    let textColor = '#24292e'; 
-                    if (label.color && label.color.length === 6) {
-                    const r = parseInt(label.color.substring(0, 2), 16);
-                    const g = parseInt(label.color.substring(2, 4), 16);
-                    const b = parseInt(label.color.substring(4, 6), 16);
-                    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-                    // If the badge background is dark, flip text to white
-                    if (brightness < 128) textColor = '#ffffff';
-                    }
+                        const bgColor = label.color ? `#${label.color}` : '#f1f3f5';
+                        
+                        // Dynamically calculate text contrast (Light vs Dark backgrounds)
+                        let textColor = '#24292e'; 
+                        if (label.color && label.color.length === 6) {
+                            const r = parseInt(label.color.substring(0, 2), 16);
+                            const g = parseInt(label.color.substring(2, 4), 16);
+                            const b = parseInt(label.color.substring(4, 6), 16);
+                            const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                            // If the badge background is dark, flip text to white
+                            if (brightness < 128) textColor = '#ffffff';
+                        }
 
+                        return `
+                            <span class="issue-tag-badge" style="
+                                background-color: ${bgColor}; 
+                                color: ${textColor}; 
+                                padding: 4px 4px; 
+                                border-radius: 20px; 
+                                font-size: 0.72rem; 
+                                font-weight: 600; 
+                                display: inline-block; 
+                                white-space: nowrap;
+                                border: 1px solid rgba(0, 0, 0, 0.08);
+                                line-height: 1;
+                            ">
+                                ${label.name}
+                            </span>
+                            `;
+                        }).join('');
+
+                    // Define 'card' for each issue with inline styles; the entire card is clickable via the anchor tag
                     return `
-                        <span class="issue-tag-badge" style="
-                            background-color: ${bgColor}; 
-                            color: ${textColor}; 
-                            padding: 4px 4px; 
-                            border-radius: 20px; 
-                            font-size: 0.72rem; 
-                            font-weight: 600; 
-                            display: inline-block; 
-                            white-space: nowrap;
-                            border: 1px solid rgba(0, 0, 0, 0.08);
-                            line-height: 1;
-                        ">
-                            ${label.name}
-                        </span>
-                        `;
-                    }).join('');
-
-                return `
-                    <li class="issue-item">
-                    <a href="${issue.html_url}" target="_blank" rel="noopener noreferrer" class="issue-link" style="text-decoration: none; color: #24292e; display: block;">
-                        <div class="issue-card-content">
-                        
-                        <div class="issue-meta" style="display: flex; justify-content: space-between; font-size: 0.85rem; color: #586069;">
-                            <span class="issue-repo-name" style="font-weight: 600; color: var(--color-primary-dark)">${repoName}</span>
-                            <span class="issue-number" style="color: var(--color-primary-dark)">#${issue.number}</span>
-                        </div>
-                        
-                        <div class="issue-title" style="font-size: 0.95rem; font-weight: 500; line-height: 1.4;">
-                            ${issue.title}
-                        </div>
-                        
-                        <div class="issue-tags-container" style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px;">
-                            ${tagsHtml}
-                        </div>
-                        
-                        </div>
-                    </a>
-                    </li>
-                `;
+                        <li class="issue-item">
+                        <a href="${issue.html_url}" target="_blank" rel="noopener noreferrer" class="issue-link" style="text-decoration: none; color: #24292e; display: block;">
+                            <div class="issue-card-content">
+                            
+                            <div class="issue-meta" style="display: flex; justify-content: space-between; font-size: 0.85rem; color: #586069;">
+                                <span class="issue-repo-name" style="font-weight: 600; color: var(--color-primary-dark)">${repoName}</span>
+                                <span class="issue-number" style="color: var(--color-primary-dark)">#${issue.number}</span>
+                            </div>
+                            
+                            <div class="issue-title" style="font-size: 0.95rem; font-weight: 500; line-height: 1.4;">
+                                ${issue.title}
+                            </div>
+                            
+                            <div class="issue-tags-container" style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px;">
+                                ${tagsHtml}
+                            </div>
+                            
+                            </div>
+                        </a>
+                        </li>
+                    `;
                 }).join('')}
             </ul>
             `;

--- a/js/load-issues.js
+++ b/js/load-issues.js
@@ -100,7 +100,7 @@ export async function loadGitHubIssues(containerId) {
                             <span class="issue-tag-badge" style="
                                 background-color: ${bgColor}; 
                                 color: ${textColor}; 
-                                padding: 4px 4px; 
+                                padding: 6px; 
                                 border-radius: 20px; 
                                 font-size: 0.72rem; 
                                 font-weight: 600; 

--- a/js/load-issues.js
+++ b/js/load-issues.js
@@ -1,0 +1,147 @@
+/**
+ * Fetches issues from ecosystem GitHub repositories based on provided labels and renders them.
+ * @param {string} containerId - The ID of the HTML element where the list will render.
+ */
+export async function loadGitHubIssues(containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        console.error(`Container with ID "${containerId}" not found.`);
+        return;
+    }
+
+    // List BioCLIP ecosystem repositories to check
+    const repos = [
+        'Imageomics/pybioclip', 
+        'Imageomics/emb-explorer',
+        'Imageomics/biobench',
+        'Imageomics/bioclip-ecosystem',
+        'Imageomics/bioclip-image-search-lite',
+        'Imageomics/distributed-downloader',
+        'Imageomics/TaxonoPy',
+        'Imageomics/TreeOfLife-Toolbox',
+        'Imageomics/Finer-CAM',
+        'Imageomics/Prompt_CAM',
+        'Imageomics/saev',
+        'Imageomics/bioclip',
+        'Imageomics/bioclip-2',
+        'Imageomics/biocap',
+        'Imageomics/bioclip-vector-db'
+        ]
+    // labels for issue filtering
+    const labels = [
+        'bug', 
+        'good first issue',
+        'help wanted'
+        ]
+
+    // Set initial loading state
+    container.innerHTML = '<p class="issue-loading">Loading matching issues...</p>';
+
+    // Setup headers (GitHub strongly recommends specifying the API version)
+    const headers = {
+        'Accept': 'application/vnd.github.v3+json'
+    };
+    
+    try {
+        // Format labels for OR logic using the comma syntax (e.g., label:"bug","good first issue")
+        const labelQuery = `label:${labels.map(l => `"${l}"`).join(',')}`;
+
+        // Format multiple repos (Separating them by spaces acts as an OR filter in GitHub search)
+        const repoQuery = repos.map(r => `repo:${r}`).join(' ');
+
+        // Combine label repo list into a single query
+        const searchQuery = `is:open is:issue ${repoQuery} ${labelQuery}`;
+        const url = `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}`;
+
+        const response = await fetch(url, { headers });
+        
+        if (!response.ok) {
+            throw new Error(`GitHub API error (${response.status})`);
+        }
+
+        const data = await response.json();
+
+        // The Search API returns elements inside an 'items' array
+        const searchItems = data.items || [];
+
+        // Filter out PRs, which GitHub treats as issues in queries
+        const issuesOnly = searchItems.filter(issue => !issue.pull_request);
+
+        // Handle empty state
+        if (issuesOnly.length === 0) {
+            container.innerHTML = `<p class="issue-empty">No open issues found matching labels (${labels.join(', ')}).</p>`;
+            return;
+        }
+
+        // Build the clickable HTML list
+        container.innerHTML = `
+            <ul class="issue-list" style="list-style: none; padding: 0; margin: 0;">
+                ${issuesOnly.map(issue => {
+                    const urlParts = issue.html_url.split('/');
+                    const repoName = urlParts[4] || 'Repository';
+
+                    // Map issue labels and build their badges with inline safety styles
+                    const tagsHtml = (issue.labels || []).map(label => {
+                    // Fallback to light gray if color is missing
+                    const bgColor = label.color ? `#${label.color}` : '#f1f3f5';
+                    
+                    // Dynamically calculate text contrast (Light vs Dark backgrounds)
+                    let textColor = '#24292e'; 
+                    if (label.color && label.color.length === 6) {
+                    const r = parseInt(label.color.substring(0, 2), 16);
+                    const g = parseInt(label.color.substring(2, 4), 16);
+                    const b = parseInt(label.color.substring(4, 6), 16);
+                    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                    // If the badge background is dark, flip text to white
+                    if (brightness < 128) textColor = '#ffffff';
+                    }
+
+                    return `
+                        <span class="issue-tag-badge" style="
+                            background-color: ${bgColor}; 
+                            color: ${textColor}; 
+                            padding: 4px 4px; 
+                            border-radius: 20px; 
+                            font-size: 0.72rem; 
+                            font-weight: 600; 
+                            display: inline-block; 
+                            white-space: nowrap;
+                            border: 1px solid rgba(0, 0, 0, 0.08);
+                            line-height: 1;
+                        ">
+                            ${label.name}
+                        </span>
+                        `;
+                    }).join('');
+
+                return `
+                    <li class="issue-item">
+                    <a href="${issue.html_url}" target="_blank" rel="noopener noreferrer" class="issue-link" style="text-decoration: none; color: #24292e; display: block;">
+                        <div class="issue-card-content">
+                        
+                        <div class="issue-meta" style="display: flex; justify-content: space-between; font-size: 0.85rem; color: #586069;">
+                            <span class="issue-repo-name" style="font-weight: 600; color: var(--color-primary-dark)">${repoName}</span>
+                            <span class="issue-number" style="color: var(--color-primary-dark)">#${issue.number}</span>
+                        </div>
+                        
+                        <div class="issue-title" style="font-size: 0.95rem; font-weight: 500; line-height: 1.4;">
+                            ${issue.title}
+                        </div>
+                        
+                        <div class="issue-tags-container" style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px;">
+                            ${tagsHtml}
+                        </div>
+                        
+                        </div>
+                    </a>
+                    </li>
+                `;
+                }).join('')}
+            </ul>
+            `;
+
+    } catch (error) {
+        console.error('Error fetching GitHub issues:', error);
+        container.innerHTML = `<p class="issue-error">Failed to load issues. Please try again later.</p>`;
+    }
+}

--- a/js/load-issues.js
+++ b/js/load-issues.js
@@ -121,11 +121,11 @@ export async function loadGitHubIssues(containerId) {
                             <div class="issue-card-content">
                             
                             <div class="issue-meta" style="display: flex; justify-content: space-between; font-size: 0.85rem; color: #586069;">
-                                <span class="issue-repo-name" style="font-weight: 600; color: var(--color-primary-dark)">${repoName}</span>
-                                <span class="issue-number" style="color: var(--color-primary-dark)">#${issue.number}</span>
+                                <span class="issue-repo-name">${repoName}</span>
+                                <span class="issue-number">#${issue.number}</span>
                             </div>
                             
-                            <div class="issue-title" style="font-size: 0.95rem; font-weight: 500; line-height: 1.4;">
+                            <div class="issue-title">
                                 ${issue.title}
                             </div>
                             

--- a/pages/community.html
+++ b/pages/community.html
@@ -79,7 +79,6 @@ TODO: Add content as it's available:
                     <p>
                         Search this centralized list of issues tagged with "good first issue", "help wanted", or "bug". Click on any issue to view details and find out how to contribute.
                     </p>
-                    <a href="https://github.com/Imageomics/bioclip-ecosystem/issues" class="btn btn-primary-software">Submit a General Question to this repo</a>
                 </div>
                 <div class="issue-box-container">
                     <div id="github-issues-list">

--- a/pages/community.html
+++ b/pages/community.html
@@ -35,14 +35,93 @@ TODO: Add content as it's available:
                 Join and engage with the BioCLIP ecosystem community. Find ways to contribute, share your work, and connect with others interested in vision models for the Tree of Life.
             </p>
             <div class="hero-actions">
-                <a href="#guide" class="btn btn-primary">Get Involved (Coming soon!)</a>
-                <!--<a href="#browse" class="btn btn-outline">Browse Involvement Opportunities</a>-->
+                <a href="#guide" class="btn btn-primary">Get Involved</a>
+                <a href="#browse" class="btn btn-outline">Browse Involvement Opportunities</a>
             </div>
         </div>
     </section>
 
+    <section id="guide" class="section">
+        <div class="container">
+            <h2 class="section-title">How would you like to get involved?</h2>
 
+            <div class="decision-guide decision-guide--grid-2">
+                <div class="guide-card">
+                    <span class="guide-icon"><i data-lucide="list"></i></span>
+                    <h3 class="guide-title">Contribute</h3>
+                    <p class="guide-desc">Find projects looking for contributors.</p>
+                    <a href="#contribute" class="guide-link">Go to contribution opportunities &rarr;</a>
+                </div>
+
+                <div class="guide-card">
+                    <span class="guide-icon"><i data-lucide="chart-no-axes-combined"></i></span>
+                    <h3 class="guide-title">Leaderboard: Test Your Model</h3>
+                    <p class="guide-desc">See how different models perform against others in the BioCLIP ecosystem.</p>
+                    <a href="#leaderboard" class="guide-link">Go to Leaderboard &rarr;</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="browse" class="section">
     
+    <!-- Contribute: open issues -->
+    <section id="contribute" class="section">
+        <div class="container">
+            <div class="component-row">
+                <div class="component-text">
+                    <span class="tag software">Contribute</span>
+                    <h2>Get Involved</h2>
+                    <p>
+                        Find projects looking for contributors, including open issues and feature requests across the BioCLIP ecosystem repositories.
+                        
+                    </p>
+                    <p>
+                        Search this centralized list of issues tagged with "good first issue", "help wanted", or "bug". Click on any issue to view details and find out how to contribute.
+                    </p>
+                    <a href="https://github.com/Imageomics/bioclip-ecosystem/issues" class="btn btn-primary-software">Submit a General Question to this repo</a>
+                </div>
+                <div class="issue-box-container">
+                    <div id="github-issues-list">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Leaderboard -->
+    <section id="leaderboard" class="section bg-light">
+        <div class="container">
+            <div class="component-row">
+                <div class="component-text">
+                    <span class="tag model">Leaderboard</span>
+                    <h2>How does your model perform?</h2>
+                    <p>
+                        Method for submitting and evaluating models for inclusion on the leaderboard is pending. In the meantime, check out the BioBench leaderboard to see how current models perform across a variety of benchmarks.
+                    </p>
+                    <!--Submit a PR with your model results?-->
+                    <!--Biobench link? or should it be embeded?-->
+                    <a href="" class="btn btn-primary">Submit Results (Coming soon!)</a>
+                    <a href="https://imageomics.github.io/biobench/" class="btn btn-outline ml-2">BioBench Leaderboard</a>
+                </div>
+                <div class="component-image img-models">
+                    <div class="icon-display">
+                        <i data-lucide="chart-no-axes-combined" class="icon-large"></i>
+                        <span class="icon-label">Leaderboard with model names, links, and performance metrics pending</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    </section>
+
+    <!---Issue box render -->
+    <script type="module">
+        import { loadGitHubIssues } from '../js/load-issues.js';
+        // Initialize the fetch and render process
+        loadGitHubIssues('github-issues-list');
+    </script>
+
 </body>
 
 </html>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -121,7 +121,7 @@ TODO: Add content
                             <li><b>Leaderboard:</b> Maintain a community leaderboard ranking BioCLIP and associated models on various biological benchmarks. Include method for submitting and evaluating models for inclusion on the leaderboard. This would include links to models and source code, in addition to the rankings.</li>
                         </ul>
                     </p>
-                    <a href="community.html" class="btn btn-primary-community">Existing Community Initiatives (Page coming soon)</a>
+                    <a href="community.html" class="btn btn-primary-community">Existing Community Initiatives</a>
                 <!-- Add link to forum:  <a href="" class="btn btn-outline ml-2">Join the conversation</a> -->
                 </div>
                 <div class="component-image img-community">

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -114,7 +114,7 @@ TODO: Add content
                     <p>
                         <ul>
                             <li><b>BioCLIP Helpdesk:</b> Centralized and community helpdesk following the open-source model of maintainer and community feedback and assistance.</li>
-                            <li><b>WildLabs Group:</b> Establish a group in the global [WildLabs community](https://wildlabs.net/en/groups) for collaboration and knowledge sharing.</li>
+                            <li><b>WildLabs Group:</b> Establish a group in the global <a href="https://wildlabs.net/en/groups" target="_blank" rel="noopener noreferrer">WildLabs community</a> for collaboration and knowledge sharing.</li>
                             <li><b>Community Forum:</b> Shared space for discussions and collaboration.</li>
                             <li><b>Community Highlights:</b> Showcase community achievements and contributions. Include a clear workflow for submitting projects to spotlight.</li>
                             <li><b>Community Contributions:</b> Centralized platform for community members to find issues and projects open to contribution.</li>


### PR DESCRIPTION
There is a leaderboard placeholder with a link to BioBench. Issue tracker searches for "bug", "help wanted", and "good first issue" across BioCLIP Ecosystem repositories.
<img width="1404" height="739" alt="Screenshot 2026-06-08 at 7 43 07 PM" src="https://github.com/user-attachments/assets/30deeb29-734b-4408-906a-c4aec487fa90" />
<img width="1385" height="528" alt="Screenshot 2026-06-08 at 7 43 18 PM" src="https://github.com/user-attachments/assets/9b22aa58-b103-48bf-aa84-06b2d2fb0a03" />
<img width="1413" height="493" alt="Screenshot 2026-06-08 at 7 43 56 PM" src="https://github.com/user-attachments/assets/af36bbb4-b1e3-49d2-a3e2-d23bb8b0a248" />


Gemini 3.5 Thinking was used to generate issue tracker code and rendering based on my specifications and a human-in-the-loop workflow. I reviewed and revised code as needed.